### PR TITLE
docs: Add OctoAcme project management overview

### DIFF
--- a/docs/docs_README_Version3.md
+++ b/docs/docs_README_Version3.md
@@ -1,0 +1,51 @@
+# OctoAcme — Project Management Overview
+
+This folder contains OctoAcme's core project management process guidance. Use this README as a concise entry point to help teams find the right process documents and understand our ways of working.
+
+Purpose
+- Centralize repeatable project practices and reduce single-person knowledge risk.
+- Provide a quick orientation to roles, artifacts, cadence, and where to find detailed docs.
+
+Key principles
+- Customer-first: prioritize measurable customer value.
+- Iterative delivery: ship small, testable increments.
+- Clear ownership: each project has a named Project Manager (PM) and Product Lead.
+- Data-informed decisions: validate with metrics.
+- Psychological safety: encourage feedback and learning.
+
+Core roles
+- Product Manager (PdM): defines outcomes and success metrics.
+- Project Manager (PM): coordinates delivery, risks, and communications.
+- Developers: implement and test features.
+- QA / Testing: validate acceptance criteria.
+- Stakeholders: provide inputs and approvals.
+
+Primary artifacts (quick)
+- Project One-pager / Charter
+- Roadmap & Release Plan
+- Sprint backlog & acceptance criteria
+- Risk register
+- Retrospective notes & action items
+
+High-level lifecycle
+1. Initiation — define problem, stakeholders, and success metrics.
+2. Planning — create backlog, estimate, and map milestones.
+3. Execution — build, test, review, iterate.
+4. Release — deploy, verify, and announce.
+5. Close & Retrospective — capture learnings and action items.
+
+Where to find more detail
+- docs/octoacme-project-initiation.md — initiation & one-pager
+- docs/octoacme-project-planning.md — planning & backlog
+- docs/octoacme-execution-and-tracking.md — day-to-day execution & CI/PR guidance
+- docs/octoacme-release-and-deployment.md — release checklist & rollback playbook
+- docs/octoacme-risks-and-communication.md — risk register & comms templates
+- docs/octoacme-retrospective-and-continuous-improvement.md — retros and improvements
+- docs/octoacme-roles-and-personas.md — role descriptions used across docs
+
+How to use this folder
+- Start with the Project One-pager in the initiation doc for new projects.
+- Link action items from retros to issues in the repo so improvements are tracked and assigned.
+- Use the Issue Template (.github/ISSUE_TEMPLATE/add-update-content-to-process-docs.yml) to propose updates to these process docs.
+
+If you'd like this README shortened, expanded, or tailored to include templates/tables of contents, tell me what to change and I’ll update the content.


### PR DESCRIPTION
Adds docs/README.md — a concise entry point summarizing OctoAcme’s project management processes.
Relates to #2